### PR TITLE
feat(emits): add  'update:currentPage' emit

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -411,6 +411,7 @@ const emits = defineEmits([
   'updateTotalItems',
   'selectAll',
   'update:itemsExpanded',
+  'update:currentPage'
 ]);
 
 const isMultipleSelectable = computed((): boolean => itemsSelected.value !== null);
@@ -504,6 +505,7 @@ const {
   rowsPerPageRef,
   serverOptions,
   updateServerOptionsPage,
+  emits
 );
 
 const {

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,7 +1,8 @@
 import {
-  ref, Ref, computed, ComputedRef,
+  ref, Ref, computed, ComputedRef, watch,
 } from 'vue';
 import type { ServerOptions } from '../types/main';
+import type { EmitsEventName } from '../types/internal';
 
 export default function usePagination(
   currentPage: Ref<number>,
@@ -11,8 +12,18 @@ export default function usePagination(
   rowsPerPage: Ref<number>,
   serverOptions: Ref<ServerOptions | null>,
   updateServerOptionsPage: (page: number) => void,
+  emits: (event: EmitsEventName, ...args: any[]) => void,
 ) {
-  const currentPaginationNumber = ref(serverOptions.value ? serverOptions.value.page : currentPage.value);
+
+  function getCurrentPaginationNumber() {
+    return serverOptions.value ? serverOptions.value.page : currentPage.value
+  }
+  const currentPaginationNumber = ref(getCurrentPaginationNumber());
+  watch(currentPage, () => {
+    currentPaginationNumber.value = getCurrentPaginationNumber()
+  })
+  watch(currentPaginationNumber, (value) =>  emits('update:currentPage', value))
+  
   const maxPaginationNumber = computed((): number => Math.ceil(totalItemsLength.value / rowsPerPage.value));
   // eslint-disable-next-line max-len
   const isLastPage = computed((): boolean => maxPaginationNumber.value === 0 || (currentPaginationNumber.value === maxPaginationNumber.value));

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -26,4 +26,4 @@ export type ClickEventType = 'single' | 'double'
 export type MultipleSelectStatus = 'allSelected' | 'noneSelected' | 'partSelected'
 
 // eslint-disable-next-line max-len
-export type EmitsEventName = 'clickRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll' | 'update:itemsExpanded'
+export type EmitsEventName = 'clickRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll' | 'update:itemsExpanded' | 'update:currentPage'


### PR DESCRIPTION
This emit is for controlling the current page from outside. A good example is having filters with the table, after applying a filter we need to reset the currentPage to the first one.

### `Type`

> What types of changes does your code introduce?

> Put an `x` in the boxes that apply_

- [ ] Fix
- [ ] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [ ] Title as described
- [ ] Add unit test by vitest if necessary
